### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JHO
 
-A bot that sends out a reply when it finds a Tweet that does not conform to JIS Z8301 Annex G.
+A bot that sends out a reply when it finds a Tweet that does not conform to JIS Z8301:2008 Annex G.
 
 ## Getting Started
 ### setup


### PR DESCRIPTION
現行のJIS Z8302:2019は長音の扱いを含む外来語の表記全般を内閣告示に委譲しているので，例の記述が少なくとも確認できる2008に戻す。
2011にも改正があったが，内容未確認であるためここでは記さない。